### PR TITLE
Use local lerna

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,7 +18,7 @@ async function cmd(command, cwd = process.cwd()) {
 }
 
 async function getPackages() {
-    const result = await cmd('lerna ls --all --json --loglevel=silent');
+    const result = await cmd('npx lerna ls --all --json --loglevel=silent');
     return JSON.parse(result);
 }
 

--- a/main.js
+++ b/main.js
@@ -4,6 +4,11 @@ const {exec} = require('child_process');
 const {promises} = require('fs');
 const {join} = require('path');
 
+process.on('unhandledRejection', (error) => {
+    console.error(error);
+    process.exit(1);
+});
+
 async function cmd(command, cwd = process.cwd()) {
     return new Promise((res, rej) => {
         exec(command, {cwd}, (err, stdout, stderr) => {


### PR DESCRIPTION
* Prefer local installation over the globally installed lerna
* Handle uncaught promise failures (e.g. during filesystem operations or command executions)